### PR TITLE
use es5's isNaN instead of es6's Number.isNaN

### DIFF
--- a/pretty-bytes.js
+++ b/pretty-bytes.js
@@ -9,7 +9,7 @@
 	'use strict';
 
 	var prettyBytes = function (num) {
-		if (typeof num !== 'number' || Number.isNaN(num)) {
+		if (typeof num !== 'number' || isNaN(num)) {
 			throw new TypeError('Input must be a number');
 		}
 


### PR DESCRIPTION
Trying to get this to work in IE. Number.isNaN [isn't available](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN#Browser_compatibility). No surprise here! :pensive: 

I thought about using a [polyfill](https://github.com/dherman/tc39-codex-wiki/blob/master/data/es6/number/index.md#polyfill-for-numberisnan) for Number.isNaN, but extending the native Number Object for this module seems like massive overkill and just bad practice overall.

There are some [quirks about isNaN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN#Confusing_special-case_behavior) that Number.isNaN was created to avoid. Checking with `typeof` before using isNaN should cover the edge cases.
