### PR TITLE
Add an option to output a JS object

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,12 @@
 'use strict';
 var numberIsNan = require('number-is-nan');
 
-module.exports = function (num) {
+module.exports = function (num, opts) {
 	if (typeof num !== 'number' || numberIsNan(num)) {
 		throw new TypeError('Expected a number, got ' + typeof num);
+	}
+	if (!opts) {
+		opts = {};
 	}
 
 	var exponent;
@@ -16,12 +19,27 @@ module.exports = function (num) {
 	}
 
 	if (num < 1) {
+		if (opts.json) {
+			return {
+				num: (neg ? -1 : 1) * num,
+				unit: 'B'
+			};
+		}
+
 		return (neg ? '-' : '') + num + ' B';
 	}
 
 	exponent = Math.min(Math.floor(Math.log(num) / Math.log(1000)), units.length - 1);
-	num = Number((num / Math.pow(1000, exponent)).toFixed(2));
+	num /= Math.pow(1000, exponent);
 	unit = units[exponent];
 
+	if (opts.json) {
+		return {
+			num: (neg ? -1 : 1) * num,
+			unit: unit
+		};
+	}
+
+	num = Number(num.toFixed(2));
 	return (neg ? '-' : '') + num + ' ' + unit;
 };

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,9 @@ prettyBytes(1337);
 
 prettyBytes(100);
 //=> '100 B'
+
+prettyBytes(1337, {json: true});
+//=> { num: 1.34, unit: 'kB' }
 ```
 
 

--- a/test.js
+++ b/test.js
@@ -28,3 +28,15 @@ test('supports negative number', t => {
 	t.is(fn(-999), '-999 B');
 	t.is(fn(-1001), '-1 kB');
 });
+
+test('converts bytes to json structure', t => {
+	t.deepEqual(fn(0, {json: true}), {num: 0, unit: 'B'});
+	t.deepEqual(fn(0.4, {json: true}), {num: 0.4, unit: 'B'});
+	t.deepEqual(fn(0.7, {json: true}), {num: 0.7, unit: 'B'});
+	t.deepEqual(fn(10, {json: true}), {num: 10, unit: 'B'});
+	t.deepEqual(fn(10.1, {json: true}), {num: 10.1, unit: 'B'});
+	t.deepEqual(fn(999, {json: true}), {num: 999, unit: 'B'});
+	t.deepEqual(fn(1001, {json: true}), {num: 1.001, unit: 'kB'});
+	t.deepEqual(fn(1e16, {json: true}), {num: 10, unit: 'PB'});
+	t.deepEqual(fn(1e30, {json: true}), {num: 1000000, unit: 'YB'});
+});


### PR DESCRIPTION
When dealing with internationalization, it could be handy to have the number and the unit separately to apply local number format and translate units.

What do you think?