### PR TITLE
Add prettyBytes.diff() method

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 const UNITS = ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 
-module.exports = num => {
+const prettyBytes = num => {
 	if (!Number.isFinite(num)) {
 		throw new TypeError(`Expected a finite number, got ${typeof num}: ${num}`);
 	}
@@ -22,3 +22,22 @@ module.exports = num => {
 
 	return (neg ? '-' : '') + numStr + ' ' + unit;
 };
+
+prettyBytes.diff = (from, to) => {
+	if (!Number.isFinite(from)) {
+		throw new TypeError(`Expected a finite number, got ${typeof from}: ${from}`);
+	}
+	if (!Number.isFinite(to)) {
+		throw new TypeError(`Expected a finite number, got ${typeof to}: ${to}`);
+	}
+
+	if (from === to) {
+		return `±0 B`;
+	}
+
+	const delta = to - from;
+	const prettyDelta = prettyBytes(delta);
+	return (delta < 0) ? prettyDelta : `+${prettyDelta}`;
+};
+
+module.exports = prettyBytes;

--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,9 @@ prettyBytes(1337);
 
 prettyBytes(100);
 //=> '100 B'
+
+prettyBytes.diff(42, 123);
+//=> '+81 B'
 ```
 
 

--- a/test.js
+++ b/test.js
@@ -31,3 +31,9 @@ test('supports negative number', t => {
 	t.is(m(-999), '-999 B');
 	t.is(m(-1001), '-1 kB');
 });
+
+test('has diff() method', t => {
+	t.is(m.diff(42, 123), '+81 B');
+	t.is(m.diff(123, 42), '-81 B');
+	t.is(m.diff(42, 42), '±0 B');
+});


### PR DESCRIPTION
This PR adds a `diff()` method to the module that calculates the diff of the two inputs, formats it using the existing logic and adds a `plus` sign if the value is positive. It also handles the corner case where both inputs are equal in which case it returns `±0 B`.

An alternative would be to add an `options` argument to the existing function with a `signed: true` option in which case the subtraction is kept outside of the scope of this module 🤔 