### PR TITLE
Add `locale` option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 before_install:
   - npm install full-icu
-after_install:
+before_script:
   - export NODE_ICU_DATA=node_modules/full-icu
 language: node_js
 node_js:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 sudo: false
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y libicu-dev
 language: node_js
 node_js:
   - '6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 before_install:
   - npm install full-icu
-env:
-  - NODE_ICU_DATA=node_modules/full-icu
+after_install:
+  - export NODE_ICU_DATA=node_modules/full-icu
 language: node_js
 node_js:
   - '6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 sudo: false
 before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get install -y libicu-dev
+  - npm install full-icu
+env:
+  - NODE_ICU_DATA=node_modules/full-icu
 language: node_js
 node_js:
   - '6'

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = (num, locale = undefined) => {
 	}
 
 	const exponent = Math.min(Math.floor(Math.log10(num) / 3), UNITS.length - 1);
-	const numStr = (num / Math.pow(1000, exponent)).toLocaleString(locale, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+	const numStr = Number(num / Math.pow(1000, exponent)).toLocaleString(locale, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 	const unit = UNITS[exponent];
 
 	return (neg ? '-' : '') + numStr + ' ' + unit;

--- a/index.js
+++ b/index.js
@@ -14,15 +14,14 @@ module.exports = (num, options) => {
 		num = -num;
 	}
 
-	let numStr;
 	if (num < 1) {
-		numStr = toLocaleString(num, options.locale);
+		const numStr = toLocaleString(num, options.locale);
 		return (neg ? '-' : '') + numStr + ' B';
 	}
 
 	const exponent = Math.min(Math.floor(Math.log10(num) / 3), UNITS.length - 1);
 	num = Number((num / Math.pow(1000, exponent)).toPrecision(3));
-	numStr = toLocaleString(num, options.locale);
+	const numStr = toLocaleString(num, options.locale);
 
 	const unit = UNITS[exponent];
 

--- a/index.js
+++ b/index.js
@@ -35,11 +35,12 @@ module.exports = (num, options) => {
  * If no value for locale is specified, the number is returned unmodified.
  */
 function toLocaleString(num, locale) {
+	let result = num;
 	if (typeof locale === 'string') {
-		return num.toLocaleString(locale);
+		result = num.toLocaleString(locale);
 	} else if (locale) {
-		return num.toLocaleString();
-	} else {
-		return num;
+		result = num.toLocaleString();
 	}
+
+	return result;
 }

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = (num, locale = undefined) => {
 	}
 
 	const exponent = Math.min(Math.floor(Math.log10(num) / 3), UNITS.length - 1);
-	const numStr = Number(num / Math.pow(1000, exponent)).toLocaleString(locale, {minimumFractionDigits: 2, maximumFractionDigits: 2});
+	const numStr = Number(num / Math.pow(1000, exponent)).toLocaleString(locale, {maximumFractionDigits: 2});
 	const unit = UNITS[exponent];
 
 	return (neg ? '-' : '') + numStr + ' ' + unit;

--- a/index.js
+++ b/index.js
@@ -32,14 +32,14 @@ module.exports = (num, options) => {
 /**
  * Formats the given number using number.toLocaleString(..).
  * If locale is a string, the value is expected to be a locale-key (e.g. 'de').
- * If locale is true or 1, the system default locale is used for translation.
+ * If locale is true, the system default locale is used for translation.
  * If no value for locale is specified, the number is returned unmodified.
  */
 function toLocaleString(num, locale) {
 	let result = num;
 	if (typeof locale === 'string') {
 		result = num.toLocaleString(locale);
-	} else if (locale) {
+	} else if (locale === true) {
 		result = num.toLocaleString();
 	}
 

--- a/index.js
+++ b/index.js
@@ -15,19 +15,31 @@ module.exports = (num, options) => {
 	}
 
 	if (num < 1) {
+		num = toLocaleString(num, options.locale);
 		return (neg ? '-' : '') + num + ' B';
 	}
 
 	const exponent = Math.min(Math.floor(Math.log10(num) / 3), UNITS.length - 1);
 	let numStr = Number((num / Math.pow(1000, exponent)).toPrecision(3));
-
-	if (typeof options.locale === 'string') {
-		numStr = numStr.toLocaleString(options.locale);
-	} else if (options.locale) {
-		numStr = numStr.toLocaleString();
-	}
+	numStr = toLocaleString(numStr, options.locale);
 
 	const unit = UNITS[exponent];
 
 	return (neg ? '-' : '') + numStr + ' ' + unit;
 };
+
+/**
+ * Formats the given number using number.toLocaleString(..).
+ * If locale is a string, the value is expected to be a locale-key (e.g. 'de').
+ * If locale is true or 1, the system default locale is used for translation.
+ * If no value for locale is specified, the number is returned unmodified.
+ */
+function toLocaleString(num, locale) {
+	if (typeof locale === 'string') {
+		return num.toLocaleString(locale);
+	} else if (locale) {
+		return num.toLocaleString();
+	} else {
+		return num;
+	}
+}

--- a/index.js
+++ b/index.js
@@ -14,14 +14,15 @@ module.exports = (num, options) => {
 		num = -num;
 	}
 
+	let numStr;
 	if (num < 1) {
-		num = toLocaleString(num, options.locale);
-		return (neg ? '-' : '') + num + ' B';
+		numStr = toLocaleString(num, options.locale);
+		return (neg ? '-' : '') + numStr + ' B';
 	}
 
 	const exponent = Math.min(Math.floor(Math.log10(num) / 3), UNITS.length - 1);
-	let numStr = Number((num / Math.pow(1000, exponent)).toPrecision(3));
-	numStr = toLocaleString(numStr, options.locale);
+	num = Number((num / Math.pow(1000, exponent)).toPrecision(3));
+	numStr = toLocaleString(num, options.locale);
 
 	const unit = UNITS[exponent];
 

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ module.exports = (num, options) => {
 	if (!Number.isFinite(num)) {
 		throw new TypeError(`Expected a finite number, got ${typeof num}: ${num}`);
 	}
+	
+	options = Object.assign({}, options);
 
 	const neg = num < 0;
 
@@ -18,7 +20,7 @@ module.exports = (num, options) => {
 
 	const exponent = Math.min(Math.floor(Math.log10(num) / 3), UNITS.length - 1);
 	const numTmp = Number((num / Math.pow(1000, exponent)).toPrecision(3));
-	const numStr = options && options.localize ? numTmp.toLocaleString() : numTmp;
+	const numStr = options.localize ? numTmp.toLocaleString() : numTmp;
 	const unit = UNITS[exponent];
 
 	return (neg ? '-' : '') + numStr + ' ' + unit;

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 const UNITS = ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 
-module.exports = num => {
+module.exports = (num, locale = undefined) => {
 	if (!Number.isFinite(num)) {
 		throw new TypeError(`Expected a finite number, got ${typeof num}: ${num}`);
 	}
@@ -17,7 +17,7 @@ module.exports = num => {
 	}
 
 	const exponent = Math.min(Math.floor(Math.log10(num) / 3), UNITS.length - 1);
-	const numStr = Number((num / Math.pow(1000, exponent)).toPrecision(3));
+	const numStr = Number(num / Math.pow(1000, exponent)).toLocaleString(locale, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 	const unit = UNITS[exponent];
 
 	return (neg ? '-' : '') + numStr + ' ' + unit;

--- a/index.js
+++ b/index.js
@@ -19,8 +19,16 @@ module.exports = (num, options) => {
 	}
 
 	const exponent = Math.min(Math.floor(Math.log10(num) / 3), UNITS.length - 1);
-	const numTmp = Number((num / Math.pow(1000, exponent)).toPrecision(3));
-	const numStr = options.localize ? numTmp.toLocaleString() : numTmp;
+	let numStr = Number((num / Math.pow(1000, exponent)).toPrecision(3));
+	
+	if (options.locale) {
+		if (typeof options.locale === "string") {
+			numStr = numStr.toLocaleString(options.locale);
+		} else if (options.locale) {
+			numStr = numStr.toLocaleString();
+		}
+	}
+
 	const unit = UNITS[exponent];
 
 	return (neg ? '-' : '') + numStr + ' ' + unit;

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 const UNITS = ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 
-module.exports = (num, locale = undefined) => {
+module.exports = (num, localize = false) => {
 	if (!Number.isFinite(num)) {
 		throw new TypeError(`Expected a finite number, got ${typeof num}: ${num}`);
 	}
@@ -17,7 +17,8 @@ module.exports = (num, locale = undefined) => {
 	}
 
 	const exponent = Math.min(Math.floor(Math.log10(num) / 3), UNITS.length - 1);
-	const numStr = Number(num / Math.pow(1000, exponent)).toLocaleString(locale, {maximumFractionDigits: 2});
+	const numTmp = Number((num / Math.pow(1000, exponent)).toPrecision(3));
+	const numStr = localize ? numTmp.toLocaleString() : numTmp;
 	const unit = UNITS[exponent];
 
 	return (neg ? '-' : '') + numStr + ' ' + unit;

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = (num, options) => {
 	if (!Number.isFinite(num)) {
 		throw new TypeError(`Expected a finite number, got ${typeof num}: ${num}`);
 	}
-	
+
 	options = Object.assign({}, options);
 
 	const neg = num < 0;

--- a/index.js
+++ b/index.js
@@ -20,9 +20,9 @@ module.exports = (num, options) => {
 
 	const exponent = Math.min(Math.floor(Math.log10(num) / 3), UNITS.length - 1);
 	let numStr = Number((num / Math.pow(1000, exponent)).toPrecision(3));
-	
+
 	if (options.locale) {
-		if (typeof options.locale === "string") {
+		if (typeof options.locale === 'string') {
 			numStr = numStr.toLocaleString(options.locale);
 		} else if (options.locale) {
 			numStr = numStr.toLocaleString();

--- a/index.js
+++ b/index.js
@@ -21,12 +21,10 @@ module.exports = (num, options) => {
 	const exponent = Math.min(Math.floor(Math.log10(num) / 3), UNITS.length - 1);
 	let numStr = Number((num / Math.pow(1000, exponent)).toPrecision(3));
 
-	if (options.locale) {
-		if (typeof options.locale === 'string') {
-			numStr = numStr.toLocaleString(options.locale);
-		} else if (options.locale) {
-			numStr = numStr.toLocaleString();
-		}
+	if (typeof options.locale === 'string') {
+		numStr = numStr.toLocaleString(options.locale);
+	} else if (options.locale) {
+		numStr = numStr.toLocaleString();
 	}
 
 	const unit = UNITS[exponent];

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = (num, locale = undefined) => {
 	}
 
 	const exponent = Math.min(Math.floor(Math.log10(num) / 3), UNITS.length - 1);
-	const numStr = Number(num / Math.pow(1000, exponent)).toLocaleString(locale, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+	const numStr = (num / Math.pow(1000, exponent)).toLocaleString(locale, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 	const unit = UNITS[exponent];
 
 	return (neg ? '-' : '') + numStr + ' ' + unit;

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = (num, locale = undefined) => {
 	}
 
 	const exponent = Math.min(Math.floor(Math.log10(num) / 3), UNITS.length - 1);
-	const numStr = Number(num / Math.pow(1000, exponent)).toLocaleString(locale, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+	const numStr = Number(num / Math.pow(1000, exponent)).toLocaleString(locale, {minimumFractionDigits: 2, maximumFractionDigits: 2});
 	const unit = UNITS[exponent];
 
 	return (neg ? '-' : '') + numStr + ' ' + unit;

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 const UNITS = ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 
-module.exports = (num, localize = false) => {
+module.exports = (num, localize) => {
 	if (!Number.isFinite(num)) {
 		throw new TypeError(`Expected a finite number, got ${typeof num}: ${num}`);
 	}

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 const UNITS = ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 
-module.exports = (num, localize) => {
+module.exports = (num, options) => {
 	if (!Number.isFinite(num)) {
 		throw new TypeError(`Expected a finite number, got ${typeof num}: ${num}`);
 	}
@@ -18,7 +18,7 @@ module.exports = (num, localize) => {
 
 	const exponent = Math.min(Math.floor(Math.log10(num) / 3), UNITS.length - 1);
 	const numTmp = Number((num / Math.pow(1000, exponent)).toPrecision(3));
-	const numStr = localize ? numTmp.toLocaleString() : numTmp;
+	const numStr = options && options.localize ? numTmp.toLocaleString() : numTmp;
 	const unit = UNITS[exponent];
 
 	return (neg ? '-' : '') + numStr + ' ' + unit;

--- a/readme.md
+++ b/readme.md
@@ -25,8 +25,30 @@ prettyBytes(1337);
 
 prettyBytes(100);
 //=> '100 B'
+
+// Localize output using german locale
+prettyBytes(1337, { locale: 'de' });
+//=> '1,34 kB'
 ```
 
+## API
+### prettyBytes(input, [options])
+#### input
+Type: `number`
+
+The number to format.
+
+#### options
+##### locale
+Type: `boolean || string`
+Default: `false` / no localization
+
+- `string`: Expects a [BCP 47 language tag](https://en.wikipedia.org/wiki/IETF_language_tag) (e.g. `en`, `de`, ...)
+- `boolean`: If `true`: Localize the output using the system/browser locale.
+
+**Note:** Localization should generally work in browsers. Node-Users have to ensure, there Node version has [full ICU-Support](https://github.com/nodejs/node/wiki/Intl):
+- if your using linux, node should be able to link to the installed system-icu automatically
+- or you install the [full-icu-package](https://github.com/unicode-org/full-icu-npm) and set the environment variable [NODE-ICU-DATA](https://github.com/nodejs/node/wiki/Intl#using-and-customizing-the-small-icu-build) to `node_modules/full-icu`
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -46,9 +46,7 @@ Default: `false` / no localization
 - `string`: Expects a [BCP 47 language tag](https://en.wikipedia.org/wiki/IETF_language_tag) (e.g. `en`, `de`, ...)
 - `boolean`: If `true`: Localize the output using the system/browser locale.
 
-**Note:** Localization should generally work in browsers. Node-Users have to ensure, there Node version has [full ICU-Support](https://github.com/nodejs/node/wiki/Intl):
-- if your using linux, node should be able to link to the installed system-icu automatically
-- or you install the [full-icu-package](https://github.com/unicode-org/full-icu-npm) and set the environment variable [NODE-ICU-DATA](https://github.com/nodejs/node/wiki/Intl#using-and-customizing-the-small-icu-build) to `node_modules/full-icu`
+**Note:** Localization should generally work in browsers. Node.js needs to be [built](https://github.com/nodejs/node/wiki/Intl) with `full-icu` or `system-icu`. Alternatively, the [full-icu](https://github.com/unicode-org/full-icu-npm) module can be used to provide support at runtime.
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -32,7 +32,7 @@ test('supports negative number', t => {
 	t.is(m(-1001), '-1 kB');
 });
 
-test('localized output'. t => {
+test('localized output', t => {
 	t.is(m(-0.4, { locale: 'de' }), '-0,4 B');
 	t.is(m(0.4, { locale: 'de' }), '0,4 B');
 	t.is(m(1001, { locale: 'de' }), '1 kB');

--- a/test.js
+++ b/test.js
@@ -33,27 +33,33 @@ test('supports negative number', t => {
 });
 
 test('localized output', t => {
-	t.is(m(-0.4, { locale: 'de' }), '-0,4 B');
-	t.is(m(0.4, { locale: 'de' }), '0,4 B');
-	t.is(m(1001, { locale: 'de' }), '1 kB');
-	t.is(m(10.1, { locale: 'de' }), '10,1 B');
-	t.is(m(1e30, { locale: 'de' }), '1.000.000 YB');
-	
-	t.is(m(-0.4, { locale: 'en' }), '-0.4 B');
-	t.is(m(0.4, { locale: 'en' }), '0.4 B');
-	t.is(m(1001, { locale: 'en' }), '1 kB');
-	t.is(m(10.1, { locale: 'en' }), '10.1 B');
-	t.is(m(1e30, { locale: 'en' }), '1,000,000 YB');
-	
-	t.is(m(-0.4, { locale: true }), '-0.4 B');
-	t.is(m(0.4, { locale: true }), '0.4 B');
-	t.is(m(1001, { locale: true }), '1 kB');
-	t.is(m(10.1, { locale: true }), '10.1 B');
-	t.is(m(1e30, { locale: true }), '1,000,000 YB');
-	
-	t.is(m(-0.4, { locale: false }), '-0.4 B');
-	t.is(m(0.4, { locale: false }), '0.4 B');
-	t.is(m(1001, { locale: false }), '1 kB');
-	t.is(m(10.1, { locale: false }), '10.1 B');
-	t.is(m(1e30, { locale: false }), '1000000 YB');
+	t.is(m(-0.4, {locale: 'de'}), '-0,4 B');
+	t.is(m(0.4, {locale: 'de'}), '0,4 B');
+	t.is(m(1001, {locale: 'de'}), '1 kB');
+	t.is(m(10.1, {locale: 'de'}), '10,1 B');
+	t.is(m(1e30, {locale: 'de'}), '1.000.000 YB');
+
+	t.is(m(-0.4, {locale: 'en'}), '-0.4 B');
+	t.is(m(0.4, {locale: 'en'}), '0.4 B');
+	t.is(m(1001, {locale: 'en'}), '1 kB');
+	t.is(m(10.1, {locale: 'en'}), '10.1 B');
+	t.is(m(1e30, {locale: 'en'}), '1,000,000 YB');
+
+	t.is(m(-0.4, {locale: true}), '-0.4 B');
+	t.is(m(0.4, {locale: true}), '0.4 B');
+	t.is(m(1001, {locale: true}), '1 kB');
+	t.is(m(10.1, {locale: true}), '10.1 B');
+	t.is(m(1e30, {locale: true}), '1,000,000 YB');
+
+	t.is(m(-0.4, {locale: false}), '-0.4 B');
+	t.is(m(0.4, {locale: false}), '0.4 B');
+	t.is(m(1001, {locale: false}), '1 kB');
+	t.is(m(10.1, {locale: false}), '10.1 B');
+	t.is(m(1e30, {locale: false}), '1000000 YB');
+
+	t.is(m(-0.4, {locale: undefined}), '-0.4 B');
+	t.is(m(0.4, {locale: undefined}), '0.4 B');
+	t.is(m(1001, {locale: undefined}), '1 kB');
+	t.is(m(10.1, {locale: undefined}), '10.1 B');
+	t.is(m(1e30, {locale: undefined}), '1000000 YB');
 });

--- a/test.js
+++ b/test.js
@@ -31,3 +31,29 @@ test('supports negative number', t => {
 	t.is(m(-999), '-999 B');
 	t.is(m(-1001), '-1 kB');
 });
+
+test('localized output'. t => {
+	t.is(m(-0.4, { locale: 'de' }), '-0,4 B');
+	t.is(m(0.4, { locale: 'de' }), '0,4 B');
+	t.is(m(1001, { locale: 'de' }), '1 kB');
+	t.is(m(10.1, { locale: 'de' }), '10,1 B');
+	t.is(m(1e30, { locale: 'de' }), '1.000.000 YB');
+	
+	t.is(m(-0.4, { locale: 'en' }), '-0.4 B');
+	t.is(m(0.4, { locale: 'en' }), '0.4 B');
+	t.is(m(1001, { locale: 'en' }), '1 kB');
+	t.is(m(10.1, { locale: 'en' }), '10.1 B');
+	t.is(m(1e30, { locale: 'en' }), '1,000,000 YB');
+	
+	t.is(m(-0.4, { locale: true }), '-0.4 B');
+	t.is(m(0.4, { locale: true }), '0.4 B');
+	t.is(m(1001, { locale: true }), '1 kB');
+	t.is(m(10.1, { locale: true }), '10.1 B');
+	t.is(m(1e30, { locale: true }), '1,000,000 YB');
+	
+	t.is(m(-0.4, { locale: false }), '-0.4 B');
+	t.is(m(0.4, { locale: false }), '0.4 B');
+	t.is(m(1001, { locale: false }), '1 kB');
+	t.is(m(10.1, { locale: false }), '10.1 B');
+	t.is(m(1e30, { locale: false }), '1000000 YB');
+});


### PR DESCRIPTION
This is meant to close #4 (I copied the parameters for .toLocaleString(..) from @silverwind , who opened the issue)

Uses `.toLocaleString(...)` to create the human readable strings for a locale.
Specifying the locale is optional. 
If ommited, the default language will be used.

Please add your thoughts on this. It was only  a first shot.