### PR TITLE
Add `signed` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,12 @@ module.exports = (number, options) => {
 
 	options = Object.assign({}, options);
 
+	if (options.signed && number === 0) {
+		return ' 0 B';
+	}
+
 	const isNegative = number < 0;
+	const prefix = isNegative ? '-' : (options.signed ? '+' : '');
 
 	if (isNegative) {
 		number = -number;
@@ -44,7 +49,7 @@ module.exports = (number, options) => {
 
 	if (number < 1) {
 		const numberString = toLocaleString(number, options.locale);
-		return (isNegative ? '-' : '') + numberString + ' B';
+		return prefix + numberString + ' B';
 	}
 
 	const exponent = Math.min(Math.floor(Math.log10(number) / 3), UNITS.length - 1);
@@ -53,5 +58,5 @@ module.exports = (number, options) => {
 
 	const unit = UNITS[exponent];
 
-	return (isNegative ? '-' : '') + numberString + ' ' + unit;
+	return prefix + numberString + ' ' + unit;
 };

--- a/readme.md
+++ b/readme.md
@@ -55,8 +55,7 @@ Type: `Object`
 Type: `boolean`<br>
 Default: `false`
 
-If `true`: Include plus sign for positive numbers. If the difference is exactly
-zero a space character will be prepended instead for better alignment.
+Include plus sign for positive numbers. If the difference is exactly zero a space character will be prepended instead for better alignment.
 
 
 ##### locale

--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,10 @@ prettyBytes(1337);
 prettyBytes(100);
 //=> '100 B'
 
+// Display file size differences
+prettyBytes(42, {signed: true});
+//=> '+42 B'
+
 // Localized output using German locale
 prettyBytes(1337, {locale: 'de'});
 //=> '1,34 kB'
@@ -45,6 +49,15 @@ The number to format.
 #### options
 
 Type: `Object`
+
+##### signed
+
+Type: `boolean`<br>
+Default: `false`
+
+If `true`: Include plus sign for positive numbers. If the difference is exactly
+zero a space character will be prepended instead for better alignment.
+
 
 ##### locale
 

--- a/test.js
+++ b/test.js
@@ -63,3 +63,9 @@ test('locale option', t => {
 	t.is(m(10.1, {locale: undefined}), '10.1 B');
 	t.is(m(1e30, {locale: undefined}), '1000000 YB');
 });
+
+test('signed option', t => {
+	t.is(m(42, {signed: true}), '+42 B');
+	t.is(m(-13, {signed: true}), '-13 B');
+	t.is(m(0, {signed: true}), ' 0 B');
+});


### PR DESCRIPTION
This PR implements the alternative API for signed numbers proposed in https://github.com/sindresorhus/pretty-bytes/pull/38:

```js
prettyBytes( 42, {signed: true}); // +42 B
prettyBytes(-13, {signed: true}); // -13 B
prettyBytes(  0, {signed: true}); //  ±0 B
```

Closes #38