### PR TITLE
Allow `locale` to contain a list of BCP47 tags

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,7 @@ declare namespace prettyBytes {
 
 		@default false
 		*/
-		readonly locale?: boolean | string | string[];
+		readonly locale?: boolean | string | readonly string[];
 
 		/**
 		Format the number as [bits](https://en.wikipedia.org/wiki/Bit) instead of [bytes](https://en.wikipedia.org/wiki/Byte). This can be useful when, for example, referring to [bit rate](https://en.wikipedia.org/wiki/Bit_rate).

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,12 +11,13 @@ declare namespace prettyBytes {
 		- If `false`: Output won't be localized.
 		- If `true`: Localize the output using the system/browser locale.
 		- If `string`: Expects a [BCP 47 language tag](https://en.wikipedia.org/wiki/IETF_language_tag) (For example: `en`, `de`, …)
+		- If `string[]`: Expects a list of [BCP 47 language tags](https://en.wikipedia.org/wiki/IETF_language_tag) (For example: `en`, `de`, …)
 
 		__Note:__ Localization should generally work in browsers. Node.js needs to be [built](https://github.com/nodejs/node/wiki/Intl) with `full-icu` or `system-icu`. Alternatively, the [`full-icu`](https://github.com/unicode-org/full-icu-npm) module can be used to provide support at runtime.
 
 		@default false
 		*/
-		readonly locale?: boolean | string;
+		readonly locale?: boolean | string | string[];
 
 		/**
 		Format the number as [bits](https://en.wikipedia.org/wiki/Bit) instead of [bytes](https://en.wikipedia.org/wiki/Byte). This can be useful when, for example, referring to [bit rate](https://en.wikipedia.org/wiki/Bit_rate).

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ Formats the given number using `Number#toLocaleString`.
 */
 const toLocaleString = (number, locale) => {
 	let result = number;
-	if (typeof locale === 'string') {
+	if (typeof locale === 'string' || Array.isArray(locale)) {
 		result = number.toLocaleString(locale);
 	} else if (locale === true) {
 		result = number.toLocaleString();

--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,7 @@ Default: `false` *(No localization)*
 
 - If `true`: Localize the output using the system/browser locale.
 - If `string`: Expects a [BCP 47 language tag](https://en.wikipedia.org/wiki/IETF_language_tag) (For example: `en`, `de`, …)
+- If `string[]`: Expects a list of [BCP 47 language tags](https://en.wikipedia.org/wiki/IETF_language_tag) (For example: `en`, `de`, …)
 
 **Note:** Localization should generally work in browsers. Node.js needs to be [built](https://github.com/nodejs/node/wiki/Intl) with `full-icu` or `system-icu`. Alternatively, the [`full-icu`](https://github.com/unicode-org/full-icu-npm) module can be used to provide support at runtime. [Node.js 13](https://nodejs.org/en/blog/release/v13.0.0/) and later ships with ICU by default.
 

--- a/test.js
+++ b/test.js
@@ -46,6 +46,12 @@ test('locale option', t => {
 		t.is(prettyBytes(10.1, {locale: 'en'}), '10.1 B');
 		t.is(prettyBytes(1e30, {locale: 'en'}), '1,000,000 YB');
 
+		t.is(prettyBytes(-0.4, {locale: ['unknown', 'de', 'en']}), '-0,4 B');
+		t.is(prettyBytes(0.4, {locale: ['unknown', 'de', 'en']}), '0,4 B');
+		t.is(prettyBytes(1001, {locale: ['unknown', 'de', 'en']}), '1 kB');
+		t.is(prettyBytes(10.1, {locale: ['unknown', 'de', 'en']}), '10,1 B');
+		t.is(prettyBytes(1e30, {locale: ['unknown', 'de', 'en']}), '1.000.000 YB');
+
 		t.is(prettyBytes(-0.4, {locale: true}), '-0.4 B');
 		t.is(prettyBytes(0.4, {locale: true}), '0.4 B');
 		t.is(prettyBytes(1001, {locale: true}), '1 kB');


### PR DESCRIPTION
`toLocaleString()` allows the first argument to be a list of BCP47 tags (see https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString). This can be useful when passing in `navigator.languages`, so it should also be allowed for `pretty-bytes`. :)

