### PR TITLE
Fix SI Prefix URL in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -35,7 +35,7 @@ declare namespace prettyBytes {
 		readonly bits?: boolean;
 
 		/**
-		Format the number using the [Binary Prefix](https://en.wikipedia.org/wiki/Binary_prefix) instead of the [SI Prefix](https://en.wikipedia.org/wiki/SI_Prefix). This can be useful for presenting memory amounts. However, this should not be used for presenting file sizes.
+		Format the number using the [Binary Prefix](https://en.wikipedia.org/wiki/Binary_prefix) instead of the [SI Prefix](https://en.wikipedia.org/wiki/SI_prefix). This can be useful for presenting memory amounts. However, this should not be used for presenting file sizes.
 
 		@default false
 


### PR DESCRIPTION
Follow-up to #65. My bad, I didn't realise that the typings duplicated what's in the README until after I'd raised the original PR.