### PR TITLE
feat: reduce code (& stack) size

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,12 +29,8 @@ module.exports = (number, options) => {
 		return ` 0 ${UNITS_FIRSTLETTER[0]}`;
 	}
 
-	const isNegative = number < 0;
-	const prefix = isNegative ? '-' : (options.signed ? '+' : '');
-
-	if (isNegative) {
-		number = -number;
-	}
+	const prefix = number < 0 ? '-' : (options.signed ? '+' : '');
+	number = Math.abs(number);
 
 	let localeOptions = Object.fromEntries(
 		Object.entries(options)

--- a/index.js
+++ b/index.js
@@ -1,53 +1,5 @@
 'use strict';
 
-const BYTE_UNITS = [
-	'B',
-	'kB',
-	'MB',
-	'GB',
-	'TB',
-	'PB',
-	'EB',
-	'ZB',
-	'YB'
-];
-
-const BIBYTE_UNITS = [
-	'B',
-	'kiB',
-	'MiB',
-	'GiB',
-	'TiB',
-	'PiB',
-	'EiB',
-	'ZiB',
-	'YiB'
-];
-
-const BIT_UNITS = [
-	'b',
-	'kbit',
-	'Mbit',
-	'Gbit',
-	'Tbit',
-	'Pbit',
-	'Ebit',
-	'Zbit',
-	'Ybit'
-];
-
-const BIBIT_UNITS = [
-	'b',
-	'kibit',
-	'Mibit',
-	'Gibit',
-	'Tibit',
-	'Pibit',
-	'Eibit',
-	'Zibit',
-	'Yibit'
-];
-
 /*
 Formats the given number using `Number#toLocaleString`.
 - If locale is a string, the value is expected to be a locale-key (for example: `de`).
@@ -55,64 +7,72 @@ Formats the given number using `Number#toLocaleString`.
 - If no value for locale is specified, the number is returned unmodified.
 */
 const toLocaleString = (number, locale, options) => {
-	let result = number;
-	if (typeof locale === 'string' || Array.isArray(locale)) {
-		result = number.toLocaleString(locale, options);
-	} else if (locale === true || options !== undefined) {
-		result = number.toLocaleString(undefined, options);
-	}
+    if (typeof locale === 'string' || Array.isArray(locale)) {
+        return number.toLocaleString(locale, options);
+    } else if (locale === true || options !== undefined) {
+        return number.toLocaleString(undefined, options);
+    }
 
-	return result;
+    return number;
 };
 
 module.exports = (number, options) => {
-	if (!Number.isFinite(number)) {
-		throw new TypeError(`Expected a finite number, got ${typeof number}: ${number}`);
-	}
+    if (!Number.isFinite(number)) {
+        throw new TypeError(`Expected a finite number, got ${typeof number}: ${number}`);
+    }
 
-	options = Object.assign({bits: false, binary: false}, options);
+    options = Object.assign({bits: false, binary: false}, options);
 
-	const UNITS = options.bits ?
-		(options.binary ? BIBIT_UNITS : BIT_UNITS) :
-		(options.binary ? BIBYTE_UNITS : BYTE_UNITS);
+    const UNITS_FIRSTLETTER = (options.bits ? "b" : "B") + "kMGTPEZY";
 
-	if (options.signed && number === 0) {
-		return ` 0 ${UNITS[0]}`;
-	}
+    if (options.signed && number === 0) {
+        return ` 0 ${UNITS_FIRSTLETTER[0]}`;
+    }
 
-	const isNegative = number < 0;
-	const prefix = isNegative ? '-' : (options.signed ? '+' : '');
+    const isNegative = number < 0;
+    const prefix = isNegative ? '-' : (options.signed ? '+' : '');
 
-	if (isNegative) {
-		number = -number;
-	}
+    if (isNegative) {
+        number = -number;
+    }
 
-	let localeOptions;
+    let localeOptions;
 
-	if (options.minimumFractionDigits !== undefined) {
-		localeOptions = {minimumFractionDigits: options.minimumFractionDigits};
-	}
+    if (options.minimumFractionDigits !== undefined) {
+        localeOptions = {
+            minimumFractionDigits: options.minimumFractionDigits
+        };
+    }
 
-	if (options.maximumFractionDigits !== undefined) {
-		localeOptions = Object.assign({maximumFractionDigits: options.maximumFractionDigits}, localeOptions);
-	}
+    if (options.maximumFractionDigits !== undefined) {
+        localeOptions = Object.assign({
+            maximumFractionDigits: options.maximumFractionDigits
+        }, localeOptions);
+    }
 
-	if (number < 1) {
-		const numberString = toLocaleString(number, options.locale, localeOptions);
-		return prefix + numberString + ' ' + UNITS[0];
-	}
+    if (number < 1) {
+        const numberString = toLocaleString(number, options.locale, localeOptions);
+        return prefix + numberString + ' ' + UNITS_FIRSTLETTER[0];
+    }
 
-	const exponent = Math.min(Math.floor(options.binary ? Math.log(number) / Math.log(1024) : Math.log10(number) / 3), UNITS.length - 1);
-	// eslint-disable-next-line unicorn/prefer-exponentiation-operator
-	number /= Math.pow(options.binary ? 1024 : 1000, exponent);
+    const exponent = Math.min(
+        Math.floor(options.binary ? Math.log(number) / Math.log(1024) : Math.log10(number) / 3),
+        UNITS_FIRSTLETTER.length - 1
+    );
+    // eslint-disable-next-line unicorn/prefer-exponentiation-operator
+    number /= Math.pow(options.binary ? 1024 : 1000, exponent);
 
-	if (!localeOptions) {
-		number = number.toPrecision(3);
-	}
+    if (!localeOptions) {
+        number = number.toPrecision(3);
+    }
 
-	const numberString = toLocaleString(Number(number), options.locale, localeOptions);
+    const numberString = toLocaleString(Number(number), options.locale, localeOptions);
 
-	const unit = UNITS[exponent];
+    let unit = UNITS_FIRSTLETTER[exponent];
+    if (exponent > 0) {
+        unit += options.binary ? "i" : "";
+        unit += options.bits ? "bit" : "B";
+    }
 
-	return prefix + numberString + ' ' + unit;
+    return prefix + numberString + ' ' + unit;
 };

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports = (number, options) => {
 	const prefix = number < 0 ? '-' : (options.signed ? '+' : '');
 	number = Math.abs(number);
 
-	let localeOptions = Object.fromEntries(
+	const localeOptions = Object.fromEntries(
 		Object.entries(options)
 		.filter(([k, _]) => k.includes('FractionDigits'))
 	);

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ Formats the given number using `Number#toLocaleString`.
 const toLocaleString = (number, locale, options) => {
 	if (typeof locale === 'string' || Array.isArray(locale)) {
 		return number.toLocaleString(locale, options);
-	} else if (locale === true || options !== undefined) {
+	} else if (locale === true || Object.keys(options).length) {
 		return number.toLocaleString(undefined, options);
 	}
 
@@ -36,19 +36,10 @@ module.exports = (number, options) => {
 		number = -number;
 	}
 
-	let localeOptions;
-
-	if (options.minimumFractionDigits !== undefined) {
-		localeOptions = {
-			minimumFractionDigits: options.minimumFractionDigits
-		};
-	}
-
-	if (options.maximumFractionDigits !== undefined) {
-		localeOptions = Object.assign({
-			maximumFractionDigits: options.maximumFractionDigits
-		}, localeOptions);
-	}
+	let localeOptions = Object.fromEntries(
+		Object.entries(options)
+		.filter(([k, _]) => k.includes('FractionDigits'))
+	);
 
 	if (number < 1) {
 		const numberString = toLocaleString(number, options.locale, localeOptions);
@@ -62,7 +53,7 @@ module.exports = (number, options) => {
 	// eslint-disable-next-line unicorn/prefer-exponentiation-operator
 	number /= Math.pow(options.binary ? 1024 : 1000, exponent);
 
-	if (!localeOptions) {
+	if (!Object.keys(localeOptions).length) {
 		number = number.toPrecision(3);
 	}
 

--- a/index.js
+++ b/index.js
@@ -7,72 +7,72 @@ Formats the given number using `Number#toLocaleString`.
 - If no value for locale is specified, the number is returned unmodified.
 */
 const toLocaleString = (number, locale, options) => {
-    if (typeof locale === 'string' || Array.isArray(locale)) {
-        return number.toLocaleString(locale, options);
-    } else if (locale === true || options !== undefined) {
-        return number.toLocaleString(undefined, options);
-    }
+	if (typeof locale === 'string' || Array.isArray(locale)) {
+		return number.toLocaleString(locale, options);
+	} else if (locale === true || options !== undefined) {
+		return number.toLocaleString(undefined, options);
+	}
 
-    return number;
+	return number;
 };
 
 module.exports = (number, options) => {
-    if (!Number.isFinite(number)) {
-        throw new TypeError(`Expected a finite number, got ${typeof number}: ${number}`);
-    }
+	if (!Number.isFinite(number)) {
+		throw new TypeError(`Expected a finite number, got ${typeof number}: ${number}`);
+	}
 
-    options = Object.assign({bits: false, binary: false}, options);
+	options = Object.assign({bits: false, binary: false}, options);
 
-    const UNITS_FIRSTLETTER = (options.bits ? "b" : "B") + "kMGTPEZY";
+	const UNITS_FIRSTLETTER = (options.bits ? 'b' : 'B') + 'kMGTPEZY';
 
-    if (options.signed && number === 0) {
-        return ` 0 ${UNITS_FIRSTLETTER[0]}`;
-    }
+	if (options.signed && number === 0) {
+		return ` 0 ${UNITS_FIRSTLETTER[0]}`;
+	}
 
-    const isNegative = number < 0;
-    const prefix = isNegative ? '-' : (options.signed ? '+' : '');
+	const isNegative = number < 0;
+	const prefix = isNegative ? '-' : (options.signed ? '+' : '');
 
-    if (isNegative) {
-        number = -number;
-    }
+	if (isNegative) {
+		number = -number;
+	}
 
-    let localeOptions;
+	let localeOptions;
 
-    if (options.minimumFractionDigits !== undefined) {
-        localeOptions = {
-            minimumFractionDigits: options.minimumFractionDigits
-        };
-    }
+	if (options.minimumFractionDigits !== undefined) {
+		localeOptions = {
+			minimumFractionDigits: options.minimumFractionDigits
+		};
+	}
 
-    if (options.maximumFractionDigits !== undefined) {
-        localeOptions = Object.assign({
-            maximumFractionDigits: options.maximumFractionDigits
-        }, localeOptions);
-    }
+	if (options.maximumFractionDigits !== undefined) {
+		localeOptions = Object.assign({
+			maximumFractionDigits: options.maximumFractionDigits
+		}, localeOptions);
+	}
 
-    if (number < 1) {
-        const numberString = toLocaleString(number, options.locale, localeOptions);
-        return prefix + numberString + ' ' + UNITS_FIRSTLETTER[0];
-    }
+	if (number < 1) {
+		const numberString = toLocaleString(number, options.locale, localeOptions);
+		return prefix + numberString + ' ' + UNITS_FIRSTLETTER[0];
+	}
 
-    const exponent = Math.min(
-        Math.floor(options.binary ? Math.log(number) / Math.log(1024) : Math.log10(number) / 3),
-        UNITS_FIRSTLETTER.length - 1
-    );
-    // eslint-disable-next-line unicorn/prefer-exponentiation-operator
-    number /= Math.pow(options.binary ? 1024 : 1000, exponent);
+	const exponent = Math.min(
+		Math.floor(options.binary ? Math.log(number) / Math.log(1024) : Math.log10(number) / 3),
+		UNITS_FIRSTLETTER.length - 1
+	);
+	// eslint-disable-next-line unicorn/prefer-exponentiation-operator
+	number /= Math.pow(options.binary ? 1024 : 1000, exponent);
 
-    if (!localeOptions) {
-        number = number.toPrecision(3);
-    }
+	if (!localeOptions) {
+		number = number.toPrecision(3);
+	}
 
-    const numberString = toLocaleString(Number(number), options.locale, localeOptions);
+	const numberString = toLocaleString(Number(number), options.locale, localeOptions);
 
-    let unit = UNITS_FIRSTLETTER[exponent];
-    if (exponent > 0) {
-        unit += options.binary ? "i" : "";
-        unit += options.bits ? "bit" : "B";
-    }
+	let unit = UNITS_FIRSTLETTER[exponent];
+	if (exponent > 0) {
+		unit += options.binary ? 'i' : '';
+		unit += options.bits ? 'bit' : 'B';
+	}
 
-    return prefix + numberString + ' ' + unit;
+	return prefix + numberString + ' ' + unit;
 };


### PR DESCRIPTION
The execution time of tests done with the previous version and with these modifications are about `1.800` (`s.ms`) (on my i5) in both cases.
In contrast, the space occupied by the code and the memory allocated on the stack are smaller (_in my opinion_, it could be useful if the library is used in webapps written, for example, with frameworks like React).

Signed-off-by: Giuseppe Eletto <peppe.eletto@gmail.com>