### PR TITLE
fix(package.json): add package.json to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
 		"url": "https://sindresorhus.com"
 	},
 	"type": "module",
-	"exports": "./index.js",
+	"exports": {
+    		".": "./index.js",
+    		"./package.json": "./package.json"
+  	},
 	"types": "./index.d.ts",
 	"engines": {
 		"node": "^14.13.1 || >=16.0.0"


### PR DESCRIPTION
If you are using bundlers like metro in rn-native (or tools that make use of metainformation of packages) you will recieve an import warning like:
```
warn Package pretty-bytes has been ignored because it contains invalid configuration. Reason: Package subpath './package.json' is not defined by "exports" in /Users/****/Applications/****/****/app/node_modules/pretty-bytes/package.json
```

There was a similar Issue in `uuidjs`, for discussion you can see this issue https://github.com/uuidjs/uuid/issues/444#issuecomment-630441826