### PR TITLE
Add `space` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -92,44 +92,40 @@ export interface Options {
 	readonly maximumFractionDigits?: number;
 
 	/**
-	The number of spaces to put between the number and unit.
+	Do not put a space between the number and unit.
 
-	If it is not set, the default value is to display 1 space between the number and unit.
-
-	 If it is set to a negative number, the number of spaces between the number and unit will be 0.
-
-	@default 1
+	@default false
 
 	@example
 	```
 	import prettyBytes from 'pretty-bytes';
-	prettyBytes(1920, {spaces: 0});
+
+	prettyBytes(1920, {noSpace: true});
 	//=> '1.9kB'
 
 	prettyBytes(1920);
 	//=> '1.92 kB'
 	```
 	*/
-	readonly spaces?: number;
+	readonly noSpace?: boolean;
 
 	/**
-	Display an uppercase K for units with the "kilo" prefix.
+	Use [JEDEC units](https://en.wikipedia.org/wiki/JEDEC_memory_standards#Unit_prefixes_for_semiconductor_storage_capacity) when `binary` is set. Only for displaying bytes (`bits` not set).
 
-	If not set, the default behavior is to display a lowercase "k" for units with the "kilo" prefix.
-
-	@default undefined
+	@default false
 
 	@example
 	```
 	import prettyBytes from 'pretty-bytes';
-	prettyBytes(1920, {uppercaseK: true});
-	//=> '1.9 KB'
 
-	prettyBytes(1920);
-	//=> '1.92 kB'
+	prettyBytes(1920, {binary: true, legacyBinaryByteUnits: true});
+	//=> '1.88 KB'
+
+	prettyBytes(1920, {binary: true});
+	//=> '1.88 kiB'
 	```
 	*/
-	readonly uppercaseKilo?: boolean;
+	readonly legacyBinaryByteUnits?: boolean;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -56,6 +56,7 @@ export interface Options {
 
 	@default undefined
 
+	@example
 	```
 	import prettyBytes from 'pretty-bytes';
 
@@ -76,6 +77,7 @@ export interface Options {
 
 	@default undefined
 
+	@example
 	```
 	import prettyBytes from 'pretty-bytes';
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -108,24 +108,6 @@ export interface Options {
 	```
 	*/
 	readonly space?: boolean;
-
-	/**
-	Use [JEDEC units](https://en.wikipedia.org/wiki/JEDEC_memory_standards#Unit_prefixes_for_semiconductor_storage_capacity) when `binary` is set. Only for displaying bytes (`bits` not set).
-
-	@default false
-
-	@example
-	```
-	import prettyBytes from 'pretty-bytes';
-
-	prettyBytes(1920, {binary: true, legacyBinaryByteUnits: true});
-	//=> '1.88 KB'
-
-	prettyBytes(1920, {binary: true});
-	//=> '1.88 kiB'
-	```
-	*/
-	readonly legacyBinaryByteUnits?: boolean;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -111,6 +111,25 @@ export interface Options {
 	```
 	*/
 	readonly spaces?: number;
+
+	/**
+	Display an uppercase K for units with the "kilo" prefix.
+
+	If not set, the default behavior is to display a lowercase "k" for units with the "kilo" prefix.
+
+	@default undefined
+
+	@example
+	```
+	import prettyBytes from 'pretty-bytes';
+	prettyBytes(1920, {uppercaseK: true});
+	//=> '1.9 KB'
+
+	prettyBytes(1920);
+	//=> '1.92 kB'
+	```
+	*/
+	readonly uppercaseKilo?: boolean;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -90,6 +90,27 @@ export interface Options {
 	```
 	*/
 	readonly maximumFractionDigits?: number;
+
+	/**
+	The number of spaces to put between the number and unit.
+
+	If it is not set, the default value is to display 1 space between the number and unit.
+
+	 If it is set to a negative number, the number of spaces between the number and unit will be 0.
+
+	@default 1
+
+	@example
+	```
+	import prettyBytes from 'pretty-bytes';
+	prettyBytes(1920, {spaces: 0});
+	//=> '1.9kB'
+
+	prettyBytes(1920);
+	//=> '1.92 kB'
+	```
+	*/
+	readonly spaces?: number;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -92,22 +92,22 @@ export interface Options {
 	readonly maximumFractionDigits?: number;
 
 	/**
-	Do not put a space between the number and unit.
+	Put a space between the number and unit.
 
-	@default false
+	@default true
 
 	@example
 	```
 	import prettyBytes from 'pretty-bytes';
 
-	prettyBytes(1920, {noSpace: true});
+	prettyBytes(1920, {space: false});
 	//=> '1.9kB'
 
 	prettyBytes(1920);
 	//=> '1.92 kB'
 	```
 	*/
-	readonly noSpace?: boolean;
+	readonly space?: boolean;
 
 	/**
 	Use [JEDEC units](https://en.wikipedia.org/wiki/JEDEC_memory_standards#Unit_prefixes_for_semiconductor_storage_capacity) when `binary` is set. Only for displaying bytes (`bits` not set).

--- a/index.js
+++ b/index.js
@@ -74,12 +74,14 @@ export default function prettyBytes(number, options) {
 		...options,
 	};
 
+	const separator = ' '.repeat(options.spaces === undefined ? 1 : Math.max(options.spaces, 0));
+
 	const UNITS = options.bits
 		? (options.binary ? BIBIT_UNITS : BIT_UNITS)
 		: (options.binary ? BIBYTE_UNITS : BYTE_UNITS);
 
 	if (options.signed && number === 0) {
-		return ` 0 ${UNITS[0]}`;
+		return ` 0${separator}${UNITS[0]}`;
 	}
 
 	const isNegative = number < 0;
@@ -101,7 +103,7 @@ export default function prettyBytes(number, options) {
 
 	if (number < 1) {
 		const numberString = toLocaleString(number, options.locale, localeOptions);
-		return prefix + numberString + ' ' + UNITS[0];
+		return prefix + numberString + separator + UNITS[0];
 	}
 
 	const exponent = Math.min(Math.floor(options.binary ? Math.log(number) / Math.log(1024) : Math.log10(number) / 3), UNITS.length - 1);
@@ -115,5 +117,5 @@ export default function prettyBytes(number, options) {
 
 	const unit = UNITS[exponent];
 
-	return prefix + numberString + ' ' + unit;
+	return prefix + numberString + separator + unit;
 }

--- a/index.js
+++ b/index.js
@@ -115,7 +115,10 @@ export default function prettyBytes(number, options) {
 
 	const numberString = toLocaleString(Number(number), options.locale, localeOptions);
 
-	const unit = UNITS[exponent];
+	let unit = UNITS[exponent];
+	if (options.uppercaseKilo && exponent === 1) {
+		unit = 'K' + unit.slice(1);
+	}
 
 	return prefix + numberString + separator + unit;
 }

--- a/index.js
+++ b/index.js
@@ -22,6 +22,18 @@ const BIBYTE_UNITS = [
 	'YiB',
 ];
 
+const LEGACY_BIBYTE_UNITS = [
+	'B',
+	'KB',
+	'MB',
+	'GB',
+	'TB',
+	'PB',
+	'EB',
+	'ZB',
+	'YB',
+];
+
 const BIT_UNITS = [
 	'b',
 	'kbit',
@@ -63,6 +75,18 @@ const toLocaleString = (number, locale, options) => {
 	return result;
 };
 
+const determineUnit = options => {
+	if (options.bits) {
+		return options.binary ? BIBIT_UNITS : BIT_UNITS;
+	}
+
+	if (options.binary) {
+		return options.legacyBinaryByteUnits ? LEGACY_BIBYTE_UNITS : BIBYTE_UNITS;
+	}
+
+	return BYTE_UNITS;
+};
+
 export default function prettyBytes(number, options) {
 	if (!Number.isFinite(number)) {
 		throw new TypeError(`Expected a finite number, got ${typeof number}: ${number}`);
@@ -71,14 +95,14 @@ export default function prettyBytes(number, options) {
 	options = {
 		bits: false,
 		binary: false,
+		legacyBinaryByteUnits: false,
+		noSpace: false,
 		...options,
 	};
 
-	const separator = ' '.repeat(options.spaces === undefined ? 1 : Math.max(options.spaces, 0));
+	const UNITS = determineUnit(options);
 
-	const UNITS = options.bits
-		? (options.binary ? BIBIT_UNITS : BIT_UNITS)
-		: (options.binary ? BIBYTE_UNITS : BYTE_UNITS);
+	const separator = options.noSpace ? '' : ' ';
 
 	if (options.signed && number === 0) {
 		return ` 0${separator}${UNITS[0]}`;
@@ -115,10 +139,7 @@ export default function prettyBytes(number, options) {
 
 	const numberString = toLocaleString(Number(number), options.locale, localeOptions);
 
-	let unit = UNITS[exponent];
-	if (options.uppercaseKilo && exponent === 1) {
-		unit = 'K' + unit.slice(1);
-	}
+	const unit = UNITS[exponent];
 
 	return prefix + numberString + separator + unit;
 }

--- a/index.js
+++ b/index.js
@@ -22,18 +22,6 @@ const BIBYTE_UNITS = [
 	'YiB',
 ];
 
-const LEGACY_BIBYTE_UNITS = [
-	'B',
-	'KB',
-	'MB',
-	'GB',
-	'TB',
-	'PB',
-	'EB',
-	'ZB',
-	'YB',
-];
-
 const BIT_UNITS = [
 	'b',
 	'kbit',
@@ -75,18 +63,6 @@ const toLocaleString = (number, locale, options) => {
 	return result;
 };
 
-const determineUnit = options => {
-	if (options.bits) {
-		return options.binary ? BIBIT_UNITS : BIT_UNITS;
-	}
-
-	if (options.binary) {
-		return options.legacyBinaryByteUnits ? LEGACY_BIBYTE_UNITS : BIBYTE_UNITS;
-	}
-
-	return BYTE_UNITS;
-};
-
 export default function prettyBytes(number, options) {
 	if (!Number.isFinite(number)) {
 		throw new TypeError(`Expected a finite number, got ${typeof number}: ${number}`);
@@ -95,12 +71,13 @@ export default function prettyBytes(number, options) {
 	options = {
 		bits: false,
 		binary: false,
-		legacyBinaryByteUnits: false,
 		space: true,
 		...options,
 	};
 
-	const UNITS = determineUnit(options);
+	const UNITS = options.bits
+		? (options.binary ? BIBIT_UNITS : BIT_UNITS)
+		: (options.binary ? BIBYTE_UNITS : BYTE_UNITS);
 
 	const separator = options.space ? ' ' : '';
 

--- a/index.js
+++ b/index.js
@@ -96,13 +96,13 @@ export default function prettyBytes(number, options) {
 		bits: false,
 		binary: false,
 		legacyBinaryByteUnits: false,
-		noSpace: false,
+		space: true,
 		...options,
 	};
 
 	const UNITS = determineUnit(options);
 
-	const separator = options.noSpace ? '' : ' ';
+	const separator = options.space ? ' ' : '';
 
 	if (options.signed && number === 0) {
 		return ` 0${separator}${UNITS[0]}`;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -7,3 +7,5 @@ expectType<string>(prettyBytes(1337, {locale: 'de'}));
 expectType<string>(prettyBytes(1337, {locale: true}));
 expectType<string>(prettyBytes(1337, {bits: true}));
 expectType<string>(prettyBytes(1337, {binary: true}));
+expectType<string>(prettyBytes(1337, {spaces: 0}));
+expectType<string>(prettyBytes(1337, {uppercaseKilo: true}));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -7,5 +7,5 @@ expectType<string>(prettyBytes(1337, {locale: 'de'}));
 expectType<string>(prettyBytes(1337, {locale: true}));
 expectType<string>(prettyBytes(1337, {bits: true}));
 expectType<string>(prettyBytes(1337, {binary: true}));
-expectType<string>(prettyBytes(1337, {spaces: 0}));
-expectType<string>(prettyBytes(1337, {uppercaseKilo: true}));
+expectType<string>(prettyBytes(1337, {noSpace: true}));
+expectType<string>(prettyBytes(1337, {legacyBinaryByteUnits: true}));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -7,5 +7,5 @@ expectType<string>(prettyBytes(1337, {locale: 'de'}));
 expectType<string>(prettyBytes(1337, {locale: true}));
 expectType<string>(prettyBytes(1337, {bits: true}));
 expectType<string>(prettyBytes(1337, {binary: true}));
-expectType<string>(prettyBytes(1337, {noSpace: true}));
+expectType<string>(prettyBytes(1337, {space: true}));
 expectType<string>(prettyBytes(1337, {legacyBinaryByteUnits: true}));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -8,4 +8,3 @@ expectType<string>(prettyBytes(1337, {locale: true}));
 expectType<string>(prettyBytes(1337, {bits: true}));
 expectType<string>(prettyBytes(1337, {binary: true}));
 expectType<string>(prettyBytes(1337, {space: true}));
-expectType<string>(prettyBytes(1337, {legacyBinaryByteUnits: true}));

--- a/readme.md
+++ b/readme.md
@@ -123,44 +123,38 @@ prettyBytes(1920);
 //=> '1.92 kB'
 ```
 
-##### spaces
+##### noSpace
 
 Type: `number`\
-Default: `1`
+Default: `false`
 
-The number of spaces to put between the number and unit.
-
-If it is not set, the default value is to display 1 space between the number and unit.
-
-If it is set to a negative number, the number of spaces between the number and unit will be 0.
+Do not put a space between the number and unit.
 
 ```js
 import prettyBytes from 'pretty-bytes';
 
-prettyBytes(1920, {spaces: 0});
+prettyBytes(1920, {noSpace: true});
 //=> '1.9kB'
 
 prettyBytes(1920);
 //=> '1.92 kB'
 ```
 
-##### uppercaseKilo
+##### legacyBinaryByteUnits
 
 Type: `boolean`\
 Default: `false`
 
-Display an uppercase K for units with the "kilo" prefix.
-
-If not set, the default behavior is to display a lowercase "k" for units with the "kilo" prefix.
+Use [JEDEC units](https://en.wikipedia.org/wiki/JEDEC_memory_standards#Unit_prefixes_for_semiconductor_storage_capacity) when `binary` is set. Only for displaying bytes (`bits` not set).
 
 ```js
 import prettyBytes from 'pretty-bytes';
 
-prettyBytes(1920, {uppercaseK: true});
-//=> '1.9 KB'
+prettyBytes(1920, {binary: true, legacyBinaryByteUnits: true});
+//=> '1.88 KB'
 
-prettyBytes(1920);
-//=> '1.92 kB'
+prettyBytes(1920, {binary: true});
+//=> '1.88 kiB'
 ```
 
 ## Related

--- a/readme.md
+++ b/readme.md
@@ -123,6 +123,26 @@ prettyBytes(1920);
 //=> '1.92 kB'
 ```
 
+##### spaces
+
+Type: `number`\
+Default: `1`
+
+The number of spaces to put between the number and unit.
+
+If it is not set, the default value is to display 1 space between the number and unit.
+
+If it is set to a negative number, the number of spaces between the number and unit will be 0.
+
+```js
+import prettyBytes from 'pretty-bytes';
+prettyBytes(1920, {spaces: 0});
+//=> '1.9kB'
+
+prettyBytes(1920);
+//=> '1.92 kB'
+```
+
 ## Related
 
 - [pretty-bytes-cli](https://github.com/sindresorhus/pretty-bytes-cli) - CLI for this module

--- a/readme.md
+++ b/readme.md
@@ -140,23 +140,6 @@ prettyBytes(1920);
 //=> '1.92 kB'
 ```
 
-##### legacyBinaryByteUnits
-
-Type: `boolean`\
-Default: `false`
-
-Use [JEDEC units](https://en.wikipedia.org/wiki/JEDEC_memory_standards#Unit_prefixes_for_semiconductor_storage_capacity) when `binary` is set. Only for displaying bytes (`bits` not set).
-
-```js
-import prettyBytes from 'pretty-bytes';
-
-prettyBytes(1920, {binary: true, legacyBinaryByteUnits: true});
-//=> '1.88 KB'
-
-prettyBytes(1920, {binary: true});
-//=> '1.88 kiB'
-```
-
 ## Related
 
 - [pretty-bytes-cli](https://github.com/sindresorhus/pretty-bytes-cli) - CLI for this module

--- a/readme.md
+++ b/readme.md
@@ -123,17 +123,17 @@ prettyBytes(1920);
 //=> '1.92 kB'
 ```
 
-##### noSpace
+##### space
 
-Type: `number`\
-Default: `false`
+Type: `boolean`\
+Default: `true`
 
-Do not put a space between the number and unit.
+Put a space between the number and unit.
 
 ```js
 import prettyBytes from 'pretty-bytes';
 
-prettyBytes(1920, {noSpace: true});
+prettyBytes(1920, {space: false});
 //=> '1.9kB'
 
 prettyBytes(1920);

--- a/readme.md
+++ b/readme.md
@@ -143,6 +143,24 @@ prettyBytes(1920);
 //=> '1.92 kB'
 ```
 
+##### uppercaseKilo
+
+Type: `boolean`\
+Default: `false`
+
+Display an uppercase K for units with the "kilo" prefix.
+
+If not set, the default behavior is to display a lowercase "k" for units with the "kilo" prefix.
+
+```js
+import prettyBytes from 'pretty-bytes';
+prettyBytes(1920, {uppercaseK: true});
+//=> '1.9 KB'
+
+prettyBytes(1920);
+//=> '1.92 kB'
+```
+
 ## Related
 
 - [pretty-bytes-cli](https://github.com/sindresorhus/pretty-bytes-cli) - CLI for this module

--- a/readme.md
+++ b/readme.md
@@ -136,6 +136,7 @@ If it is set to a negative number, the number of spaces between the number and u
 
 ```js
 import prettyBytes from 'pretty-bytes';
+
 prettyBytes(1920, {spaces: 0});
 //=> '1.9kB'
 
@@ -154,6 +155,7 @@ If not set, the default behavior is to display a lowercase "k" for units with th
 
 ```js
 import prettyBytes from 'pretty-bytes';
+
 prettyBytes(1920, {uppercaseK: true});
 //=> '1.9 KB'
 

--- a/test.js
+++ b/test.js
@@ -147,24 +147,24 @@ test('fractional digits options', t => {
 	t.is(prettyBytes(65_536, {minimumFractionDigits: 1, maximumFractionDigits: 3, binary: true}), '64.0 kiB');
 });
 
-test('spaces option', t => {
+test('noSpace option', t => {
 	t.is(prettyBytes(0), '0 B');
-	t.is(prettyBytes(0, {spaces: 0}), '0B');
-	t.is(prettyBytes(999, {spaces: 0}), '999B');
-	t.is(prettyBytes(999, {spaces: 2}), '999  B');
-	t.is(prettyBytes(-13, {signed: true, spaces: 0}), '-13B');
-	t.is(prettyBytes(-13, {signed: true, spaces: 3}), '-13   B');
-	t.is(prettyBytes(42, {signed: true, spaces: 0}), '+42B');
-	t.is(prettyBytes(42, {signed: true, spaces: 2}), '+42  B');
+	t.is(prettyBytes(0, {noSpace: true}), '0B');
+	t.is(prettyBytes(999), '999 B');
+	t.is(prettyBytes(999, {noSpace: true}), '999B');
+	t.is(prettyBytes(-13, {signed: true}), '-13 B');
+	t.is(prettyBytes(-13, {signed: true, noSpace: true}), '-13B');
+	t.is(prettyBytes(42, {signed: true}), '+42 B');
+	t.is(prettyBytes(42, {signed: true, noSpace: true}), '+42B');
 });
 
-test('uppercaseKilo option', t => {
+test('legacyBinaryByteUnits option', t => {
 	t.is(prettyBytes(1001), '1 kB');
 	t.is(prettyBytes(1025, {binary: true}), '1 kiB');
 	t.is(prettyBytes(1001, {bits: true}), '1 kbit');
 	t.is(prettyBytes(1025, {bits: true, binary: true}), '1 kibit');
-	t.is(prettyBytes(1001, {uppercaseKilo: true}), '1 KB');
-	t.is(prettyBytes(1025, {binary: true, uppercaseKilo: true}), '1 KiB');
-	t.is(prettyBytes(1001, {bits: true, uppercaseKilo: true}), '1 Kbit');
-	t.is(prettyBytes(1025, {bits: true, binary: true, uppercaseKilo: true}), '1 Kibit');
+	t.is(prettyBytes(1001, {legacyBinaryByteUnits: true}), '1 kB');
+	t.is(prettyBytes(1025, {binary: true, legacyBinaryByteUnits: true}), '1 KB');
+	t.is(prettyBytes(1001, {bits: true, legacyBinaryByteUnits: true}), '1 kbit');
+	t.is(prettyBytes(1025, {bits: true, binary: true, legacyBinaryByteUnits: true}), '1 kibit');
 });

--- a/test.js
+++ b/test.js
@@ -146,3 +146,14 @@ test('fractional digits options', t => {
 	t.is(prettyBytes(32_768, {minimumFractionDigits: 2, maximumFractionDigits: 3, binary: true}), '32.00 kiB');
 	t.is(prettyBytes(65_536, {minimumFractionDigits: 1, maximumFractionDigits: 3, binary: true}), '64.0 kiB');
 });
+
+test('spaces option', t => {
+	t.is(prettyBytes(0), '0 B');
+	t.is(prettyBytes(0, {spaces: 0}), '0B');
+	t.is(prettyBytes(999, {spaces: 0}), '999B');
+	t.is(prettyBytes(999, {spaces: 2}), '999  B');
+	t.is(prettyBytes(-13, {signed: true, spaces: 0}), '-13B');
+	t.is(prettyBytes(-13, {signed: true, spaces: 3}), '-13   B');
+	t.is(prettyBytes(42, {signed: true, spaces: 0}), '+42B');
+	t.is(prettyBytes(42, {signed: true, spaces: 2}), '+42  B');
+});

--- a/test.js
+++ b/test.js
@@ -147,15 +147,15 @@ test('fractional digits options', t => {
 	t.is(prettyBytes(65_536, {minimumFractionDigits: 1, maximumFractionDigits: 3, binary: true}), '64.0 kiB');
 });
 
-test('noSpace option', t => {
+test('space option', t => {
 	t.is(prettyBytes(0), '0 B');
-	t.is(prettyBytes(0, {noSpace: true}), '0B');
+	t.is(prettyBytes(0, {space: false}), '0B');
 	t.is(prettyBytes(999), '999 B');
-	t.is(prettyBytes(999, {noSpace: true}), '999B');
+	t.is(prettyBytes(999, {space: false}), '999B');
 	t.is(prettyBytes(-13, {signed: true}), '-13 B');
-	t.is(prettyBytes(-13, {signed: true, noSpace: true}), '-13B');
+	t.is(prettyBytes(-13, {signed: true, space: false}), '-13B');
 	t.is(prettyBytes(42, {signed: true}), '+42 B');
-	t.is(prettyBytes(42, {signed: true, noSpace: true}), '+42B');
+	t.is(prettyBytes(42, {signed: true, space: false}), '+42B');
 });
 
 test('legacyBinaryByteUnits option', t => {

--- a/test.js
+++ b/test.js
@@ -157,14 +157,3 @@ test('space option', t => {
 	t.is(prettyBytes(42, {signed: true}), '+42 B');
 	t.is(prettyBytes(42, {signed: true, space: false}), '+42B');
 });
-
-test('legacyBinaryByteUnits option', t => {
-	t.is(prettyBytes(1001), '1 kB');
-	t.is(prettyBytes(1025, {binary: true}), '1 kiB');
-	t.is(prettyBytes(1001, {bits: true}), '1 kbit');
-	t.is(prettyBytes(1025, {bits: true, binary: true}), '1 kibit');
-	t.is(prettyBytes(1001, {legacyBinaryByteUnits: true}), '1 kB');
-	t.is(prettyBytes(1025, {binary: true, legacyBinaryByteUnits: true}), '1 KB');
-	t.is(prettyBytes(1001, {bits: true, legacyBinaryByteUnits: true}), '1 kbit');
-	t.is(prettyBytes(1025, {bits: true, binary: true, legacyBinaryByteUnits: true}), '1 kibit');
-});

--- a/test.js
+++ b/test.js
@@ -157,3 +157,14 @@ test('spaces option', t => {
 	t.is(prettyBytes(42, {signed: true, spaces: 0}), '+42B');
 	t.is(prettyBytes(42, {signed: true, spaces: 2}), '+42  B');
 });
+
+test('uppercaseKilo option', t => {
+	t.is(prettyBytes(1001), '1 kB');
+	t.is(prettyBytes(1025, {binary: true}), '1 kiB');
+	t.is(prettyBytes(1001, {bits: true}), '1 kbit');
+	t.is(prettyBytes(1025, {bits: true, binary: true}), '1 kibit');
+	t.is(prettyBytes(1001, {uppercaseKilo: true}), '1 KB');
+	t.is(prettyBytes(1025, {binary: true, uppercaseKilo: true}), '1 KiB');
+	t.is(prettyBytes(1001, {bits: true, uppercaseKilo: true}), '1 Kbit');
+	t.is(prettyBytes(1025, {bits: true, binary: true, uppercaseKilo: true}), '1 Kibit');
+});


### PR DESCRIPTION
Hi!

I added a new option to this library, as I found it useful!
- `space`: when set to `false`, there won't be a space between the number and the unit.

Let me know if you have any concerns, questions or suggestions! Cheers!