### PR TITLE
docs(github): add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Description
+
+<!-- Briefly describe what this PR changes and why. -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation
+- [ ] Refactor / cleanup
+- [ ] Other:
+
+## Checklist
+
+- [ ] I have read the contributing guidelines.
+- [ ] I have tested this change locally.
+- [ ] I have updated documentation where relevant.
+- [ ] This PR does not introduce any breaking changes (or the description
+      above explains them).
+
+## Related issues
+
+<!-- e.g. Closes #123 -->


### PR DESCRIPTION
Small chore: adds a PR template. New PRs will get a lightweight checklist for description, type-of-change, and a couple of contributor checkboxes.

Doesn't force anything â€” GitHub just pre-fills the description field.